### PR TITLE
ci: bootstrap first crates.io publish with static token (temporary)

### DIFF
--- a/.github/workflows/publish-cargo.yml
+++ b/.github/workflows/publish-cargo.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: publish-cargo-${{ github.event.release.tag_name }}
@@ -29,11 +28,13 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Authenticate to crates.io via OIDC
-        id: auth
-        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
-
+      # TEMPORARY: bootstrap publish for a brand-new crate. crates.io Trusted
+      # Publishing is per-crate and requires the crate to already exist, so
+      # the very first publish has to use a static API token. After this
+      # release, configure Trusted Publishing on crates.io/crates/shamefile,
+      # restore the OIDC auth step, drop CARGO_REGISTRY_TOKEN and id-token
+      # permission. Tracked in a follow-up issue.
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --locked


### PR DESCRIPTION
## Summary

Temporarily switches \`publish-cargo.yml\` from OIDC Trusted Publishing to a static \`CARGO_REGISTRY_TOKEN\` secret. Required for the first ever publish of \`shamefile\` to crates.io because Trusted Publishing on crates.io is per-crate and cannot be configured for a crate that does not yet exist.

After the first release succeeds, follow #13 to:
1. Configure Trusted Publishing on the now-existing crate
2. Revert this workflow to OIDC
3. Revoke the bootstrap token + delete the secret

## Verification before merge

- \`CARGO_REGISTRY_TOKEN\` is set as an **environment secret** in env \`crates-io\` (not repo-level)
- Token has minimal scope (publish-new) and short expiration (7 days)