### PR TITLE
chore: add crates.io publish metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0-rc.1"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"
+description = "Turn linter suppressions from silent technical debt into reviewable, documented decisions."
+repository = "https://github.com/BKDDFS/shamefile"
+homepage = "https://github.com/BKDDFS/shamefile"
+documentation = "https://github.com/BKDDFS/shamefile#readme"
+readme = "README.md"
+keywords = ["cli", "linter", "suppressions", "code-quality", "pre-commit"]
+categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]
 name = "shame"


### PR DESCRIPTION
## Summary

Adds the metadata fields cargo publish complains about being missing:
- \`description\` — one-liner shown on crates.io listing
- \`repository\`, \`homepage\`, \`documentation\` — links on the listing
- \`readme = "README.md"\` — README rendered on the crate page
- \`keywords\` and \`categories\` — discoverability via crates.io search and category browse

Required before the first publish so the crate page on crates.io is not blank. Confirmed locally with \`cargo publish --dry-run\` — warning gone, package builds and validates.

## Test plan

- [ ] \`cargo publish --dry-run --locked\` passes without warnings (verified locally pre-PR)