### PR TITLE
fix(cli): expose --version flag and bump to 0.1.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "shamefile"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shamefile"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ fn is_entry_in_scope(
 
 #[derive(Parser)]
 #[command(name = "shame")]
+#[command(version)]
 #[command(about = "A tool to enforce documentation for code suppressions", long_about = None)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

Adds the missing \`#[command(version)]\` to the Cli derive. clap requires this attribute to register the \`--version\` flag — without it, \`shame --version\` returns \`error: unexpected argument '--version' found\`.

This caused all smoke tests in publish-npm.yml and publish-pypi.yml to fail on the v0.1.0-rc.1 release, blocking publish jobs (which depend on smoke tests).

## What changed

- \`src/main.rs\`: \`#[command(version)]\` on the \`Cli\` struct → clap pulls version from \`CARGO_PKG_VERSION\` at build time.
- \`Cargo.toml\`: bump 0.1.0-rc.1 → 0.1.0-rc.2 (rc.1 is already published on crates.io and cannot be republished; pyproject.toml is dynamic so no change needed there).
- \`Cargo.lock\`: regenerated.

## Verification

\`\`\`
$ ./target/release/shame --version
shame 0.1.0-rc.2
\`\`\`

Once merged, cut a \`v0.1.0-rc.2\` GitHub prerelease — this time all 3 publish workflows should succeed (crates.io now has Trusted Publishing configured, OIDC auth will work).