### PR TITLE
ci(npm): migrate publish from NPM_TOKEN to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -255,8 +255,8 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Update npm to latest (>=11.5.1 required for Trusted Publishing OIDC)
-        run: npm install -g npm@latest
+      - name: Update npm (>=11.5.1 required for Trusted Publishing OIDC)
+        run: npm install -g npm@11.13.0
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -252,8 +252,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm to latest (>=11.5.1 required for Trusted Publishing OIDC)
+        run: npm install -g npm@latest
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -264,7 +267,6 @@ jobs:
       - name: Assemble and publish platform packages
         shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.setup.outputs.version }}
           NPM_TAG: ${{ needs.setup.outputs.npm_tag }}
         run: |
@@ -314,7 +316,6 @@ jobs:
       - name: Publish main wrapper package
         shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.setup.outputs.version }}
           NPM_TAG: ${{ needs.setup.outputs.npm_tag }}
         run: |


### PR DESCRIPTION
## Summary

Drops the long-lived \`NPM_TOKEN\` secret in favor of GitHub Actions OIDC token exchange with npm. Every publish from here on mints a short-lived credential per workflow run, no static credential to rotate or leak.

## Workflow changes

- \`node-version\`: 20 → **24** (current Active LTS as of October 2025; ships with npm 11.x).
- Adds \`npm install -g npm@latest\` step to guarantee npm ≥ 11.5.1 (OIDC floor).
- Removes \`NODE_AUTH_TOKEN\` env from both publish steps. \`id-token: write\` permission is already granted (was needed for provenance attestation).

## Prerequisites — DO BEFORE MERGE

Configure Trusted Publishers on all 9 npm packages. For each package on npmjs.com → package settings → **Trusted Publishers** → Add:
- Repository owner: \`BKDDFS\`
- Repository name: \`shamefile\`
- Workflow filename: \`publish-npm.yml\`
- Environment name: \`npm\`

Packages:
- \`shamefile\` (wrapper)
- \`shamefile-linux-x64\`
- \`shamefile-linux-arm64\`
- \`shamefile-linux-x64-musl\`
- \`shamefile-linux-arm64-musl\`
- \`shamefile-darwin-x64\`
- \`shamefile-darwin-arm64\`
- \`shamefile-windows-x64\`
- \`shamefile-windows-arm64\`

Without this, the next release will fail npm auth.

## Cleanup after first OIDC publish succeeds

- GitHub: Settings → Environments → \`npm\` → delete \`NPM_TOKEN\` secret.
- npmjs.com: Account → Access Tokens → revoke the Classic Automation token.

## Test plan

- [ ] All 9 Trusted Publishers configured on npmjs.com
- [ ] Merge this PR
- [ ] Cut next release (v0.1.0 stable) — verify npm publish job succeeds via OIDC
- [ ] No \`NODE_AUTH_TOKEN\` references in run logs (confirms token path is dead)
- [ ] Provenance attestations still attached to packages

Closes #11.