### PR TITLE
chore: release v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "shamefile"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shamefile"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Promotes 0.1.0-rc.3 → 0.1.0 in Cargo.toml. release-plz was supposed to open this PR automatically but hit a 403 before the "Allow GitHub Actions to create and approve pull requests" workflow permission was enabled.

The (broken) v0.1.0 tag and release that release-plz created in the meantime were deleted because they pointed at a commit where Cargo.toml still said "0.1.0-rc.3", causing all three publish workflows to fail with "version already exists" / "file already exists".

## After merge

Either release-plz creates the v0.1.0 tag + GitHub Release on the next push to main, or cut it manually from the UI. Either way, the tag will point at a commit where Cargo.toml correctly says 0.1.0, and publish-cargo / publish-pypi / publish-npm will all succeed.

## What changed

- \`Cargo.toml\`: version 0.1.0-rc.3 → 0.1.0
- \`Cargo.lock\`: regenerated
- \`pyproject.toml\` is dynamic — auto-syncs at maturin build time

## Why not let release-plz handle this on its own now?

It can't see this is a "drop the prerelease suffix" situation; it sees a v0.1.0 tag in the past (now deleted) and a Cargo.toml at rc.3 and proposes rc.4 (PR #21, closed). Manual override is faster than fighting its heuristics.