### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, SECURITY

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something is broken or behaves incorrectly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in every
+        section — bug reports without repro steps and a version are very
+        hard to act on.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong, in one or two sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal commands and inputs that reproduce the bug.
+      placeholder: |
+        1. Run `shame me .` in a fresh repo
+        2. Edit shamefile.yaml as follows: ...
+        3. Run `shame check .`
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include relevant output, error messages, or stack traces.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: shame version
+      description: Output of `shame --version`.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (please describe in summary)
+    validations:
+      required: true
+
+  - type: input
+    id: install
+    attributes:
+      label: Install method
+      description: cargo, npm, pip, from source, ...
+      placeholder: "cargo install shame"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ideas / design discussions
+    url: https://github.com/BKDDFS/shamefile/discussions/categories/ideas
+    about: Open-ended ideas, design questions, "should we do X?"
+  - name: Q&A
+    url: https://github.com/BKDDFS/shamefile/discussions/categories/q-a
+    about: Usage questions and troubleshooting help.
+  - name: Security vulnerability
+    url: https://github.com/BKDDFS/shamefile/security/advisories/new
+    about: Report a security issue privately. Do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose a concrete, scoped enhancement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For open-ended ideas or design questions, please open a
+        [Discussion under Ideas](https://github.com/BKDDFS/shamefile/discussions/categories/ideas)
+        instead. Use this template only when the proposal is concrete
+        enough to act on.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? Who is affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should the tool do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered, or workarounds you tried.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope check
+      description: |
+        Does this fit within shamefile's stated scope (detect linter
+        suppressions, demand justification, gate CI)? If not, link the
+        Discussion where direction was agreed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/language_request.md
+++ b/.github/ISSUE_TEMPLATE/language_request.md
@@ -2,7 +2,7 @@
 name: Add a language
 about: Track adding support for a new language. Tick boxes as you go.
 title: "lang: add support for <language>"
-labels: ["enhancement", "language"]
+labels: ["enhancement", "language", "good first issue"]
 ---
 
 Adding a language to shamefile is mechanical. Tick each box as you
@@ -12,6 +12,22 @@ complete it, then link the PR with `Closes #<this-issue>`.
 > first contribution and we keep this opportunity open for new
 > contributors. If you have already had a language PR merged, please do
 > not open another one.
+
+## Tiers
+
+Language support has two tiers:
+
+- **`experimental`** — sanity-tested and merged into shamefile. Listed
+  in the README's *Experimental* table. The checklist below
+  covers this tier and is the well-scoped first contribution this
+  template is about.
+- **`released`** — promoted to the README's main *Supported tokens*
+  table after a matching showcase entry lands in
+  [`shamefile-showcase`](https://github.com/BKDDFS/shamefile-showcase).
+  Optional follow-up tracked in a **separate issue and PR** — after
+  merging this issue's PR, open a new issue using the *Verify and release a language*
+  template if you want to pursue `released`. Do not bundle showcase
+  work into this issue or PR.
 
 ## Language
 
@@ -81,6 +97,17 @@ findings so a maintainer can decide whether to keep it open or close it.
 - [ ] `cargo test` passes locally.
 - [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes.
 - [ ] **Sanity check on a real codebase** — exercise the new language end-to-end against unfamiliar code. Steps:
+
+  > **Tip — pick a popular project here and you can fast-track to
+  > `released`.** If the project you clone for the sanity check is one
+  > you would be willing to showcase, fork it under your own account
+  > (instead of, or in addition to, the throwaway clone). After this
+  > issue's PR is merged you can reuse that same fork for the
+  > *Verify and release a language* flow without rerunning shamefile on a different
+  > project, and the language jumps from *Experimental tokens* to
+  > *Supported tokens* in the next promotion PR rather than sitting at
+  > `experimental` indefinitely.
+
   1. Build a release binary with your changes:
      ```sh
      cargo build --release
@@ -109,9 +136,24 @@ findings so a maintainer can decide whether to keep it open or close it.
   > tracker first asking whether they want it. Unsolicited setup PRs
   > are noise for maintainers.
 - [ ] [README](../blob/main/README.md) updated with the new language. Specifically:
-  - Add a row per token to the **Supported tokens** table, matching the format of the existing Python / JavaScript / TypeScript rows (token in backticks, source tool, language column with the new language name).
+  - Add a single row with the language name to the **Experimental tokens** table. New languages start under *Experimental tokens*; promotion to *Supported tokens* (with full token / tool rows) happens via a separate showcase PR.
   - Add the file extension(s) to the **Supported file extensions** list.
   - Keep alphabetical / logical grouping consistent with existing entries.
+
+## After merge
+
+This issue ends at `experimental` and will be closed by the merging
+PR. The next step toward `released` is a **separate** issue using the
+*Verify and release a language* template — it is itself a good-first-issue, open to
+any contributor (not just you), and tracks forking a representative
+project, running shamefile against it, and merging the result into
+[`shamefile-showcase`](https://github.com/BKDDFS/shamefile-showcase).
+Do not extend this PR to cover that work.
+
+If you took the tip in the sanity-check step and used a popular
+project (forked under your account), you have a head start on the
+showcase issue and may want to claim it yourself before someone else
+does — but the issue is open to anyone.
 
 ## Notes
 

--- a/.github/ISSUE_TEMPLATE/language_request.md
+++ b/.github/ISSUE_TEMPLATE/language_request.md
@@ -1,0 +1,118 @@
+---
+name: Add a language
+about: Track adding support for a new language. Tick boxes as you go.
+title: "lang: add support for <language>"
+labels: ["enhancement", "language"]
+---
+
+Adding a language to shamefile is mechanical. Tick each box as you
+complete it, then link the PR with `Closes #<this-issue>`.
+
+> **One language per contributor.** Adding a language is a well-scoped
+> first contribution and we keep this opportunity open for new
+> contributors. If you have already had a language PR merged, please do
+> not open another one.
+
+## Language
+
+- Name:
+- File extensions:
+- Tree-sitter grammar:
+
+## Pre-flight checks
+
+Before opening a PR, confirm the language is implementable. If either of
+these fails, **do not** open a PR — comment on this issue with your
+findings so a maintainer can decide whether to keep it open or close it.
+
+- [ ] **A `tree-sitter-<lang>` Rust crate is published on crates.io.**
+  Search [crates.io](https://crates.io/search?q=tree-sitter-) for the
+  crate. The crate must:
+  - export a `LANGUAGE` constant (or equivalent function) usable from
+    Rust;
+  - declare a `tree-sitter` dependency compatible with the version
+    pinned in [`Cargo.toml`](../blob/main/Cargo.toml).
+
+  A grammar that exists only as a C / JavaScript repo (no Rust binding
+  on crates.io) does **not** qualify. Adding bindings is a separate,
+  much larger contribution and is out of scope for this template.
+
+- [ ] **The language has at least one inline suppression token** used in
+  practice (linter, type checker, formatter, compiler attribute, IDE
+  inspection, security scanner, coverage tool, or cross-language SaaS).
+  shamefile is built around inline suppressions; languages with no
+  inline suppression mechanism are not in scope. The existing test
+  suite enforces this (`every_language_has_tokens` in
+  [`src/languages.rs`](../blob/main/src/languages.rs)).
+
+## Checklist
+
+- [ ] Add the `tree-sitter-<lang>` dependency to [`Cargo.toml`](../blob/main/Cargo.toml).
+- [ ] Add a `Language` entry to [`src/languages.rs`](../blob/main/src/languages.rs) under `LANGUAGES`:
+  - [ ] `name`
+  - [ ] `extensions` (no leading dot)
+  - [ ] `tokens` — suppression tokens used by the language's ecosystem. Cover every category that applies; not all languages have all of these.
+    - [ ] every token has a trailing `// <tool>` comment naming the linter, type checker, formatter, or other tool the token comes from (matches the convention in existing entries)
+    - [ ] **Linters and type checkers** native to the language (e.g. ruff, mypy, eslint, clippy, golangci-lint).
+    - [ ] **Formatters** with inline disables (e.g. `# fmt: off` for Black/Ruff, `// prettier-ignore`).
+    - [ ] **Compiler / language built-in suppression attributes** — often the most widespread:
+      - Rust: `#[allow(...)]`, `#[expect(...)]`
+      - Java: `@SuppressWarnings("...")`
+      - C#: `#pragma warning disable`, `[SuppressMessage(...)]`
+      - Kotlin: `@Suppress("...")`
+      - C / C++: `#pragma GCC diagnostic ignored`, `#pragma clang diagnostic ignored`, `#pragma warning(disable: ...)` (MSVC)
+    - [ ] **JetBrains IDE inspection** — works in IntelliJ / PyCharm / WebStorm / Rider / GoLand and is easy to miss: `// noinspection`, `# noinspection`.
+    - [ ] **Per-language security scanners** — e.g. Bandit (`# nosec`), gosec (`// #nosec`), Brakeman (`# brakeman:ignore`).
+    - [ ] **Per-language coverage tools** — e.g. coverage.py (`# pragma: no cover`), istanbul / c8 (`/* istanbul ignore */`), tarpaulin (Rust), SimpleCov (Ruby).
+    - [ ] **Cross-language tools** with inline suppression — each tool's comment prefix differs per language; they are NOT handled universally. Examples to research: SonarQube / SonarLint (`NOSONAR`), DeepSource (`skipcq`), SemGrep (`nosemgrep`), Snyk Code (`deepcode ignore`), Coverity (`coverity[...]`).
+  - [ ] `grammar` — closure returning the tree-sitter language
+  - [ ] `comment_types` — tree-sitter node names treated as comments. The default in existing entries is `["comment"]`, but many grammars expose `line_comment` and `block_comment` as separate node types instead. Verify by one of:
+    - Reading the grammar's `node-types.json` (shipped in most published crates) and listing every node whose name contains `comment`.
+    - Reading the grammar's `grammar.js` source and looking at the `$.comment` / `$.line_comment` rules.
+    - Writing a throwaway test that parses a small sample (one line comment, one block comment if applicable) and prints `node.kind()` for every node — adjust `comment_types` until both styles are covered.
+- [ ] All file extensions for the language are covered, including edge cases:
+  - [ ] Stub / declaration files (e.g. `.pyi` for Python, `.d.ts` for TypeScript).
+  - [ ] Multi-language container files (e.g. `.vue`, `.svelte`) — call out in the PR if they are out of scope, since they need additional handling.
+  - [ ] Shebang-only scripts without an extension are out of scope. For languages where shebang-only is the dominant pattern (e.g. shell scripts), this is a **partial** language addition — proceed only if a meaningful share of real-world code uses an extension, and clearly document the limitation in the PR description.
+- [ ] Tests in `src/languages.rs`:
+  - [ ] `<lang>_found_by_extension`
+  - [ ] One assertion confirming a representative suppression token is recognized
+  - [ ] One assertion confirming a foreign token is NOT recognized
+- [ ] `cargo test` passes locally.
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes.
+- [ ] **Sanity check on a real codebase** — exercise the new language end-to-end against unfamiliar code. Steps:
+  1. Build a release binary with your changes:
+     ```sh
+     cargo build --release
+     ```
+  2. Clone a representative open-source project written in this language somewhere **outside this repo**:
+     ```sh
+     git clone --depth=1 https://github.com/<org>/<repo> /tmp/sanity
+     ```
+  3. Run shame in normal (write) mode against it. This generates a `shamefile.yaml` inside `/tmp/sanity` — a local-only file you will throw away, do **not** commit or push it back to that project:
+     ```sh
+     ./target/release/shame me /tmp/sanity
+     ```
+  4. Open the generated `/tmp/sanity/shamefile.yaml` and spot-check entries:
+     - Real suppressions, not false positives.
+     - `location`, `token`, and metadata look right.
+     - Output is well-formed YAML and renders cleanly in `git diff`.
+  5. Run `--dry-run` mode (CI path) and confirm it agrees with the saved registry:
+     ```sh
+     ./target/release/shame me --dry-run /tmp/sanity
+     ```
+  6. In the PR description, include: the project URL, its commit SHA, the suppression count, and any anomalies.
+
+  > **Please do not open a PR against the upstream project** introducing
+  > `shamefile.yaml` to their repo as part of testing. If you think a
+  > project would benefit from shamefile, open an issue in **their**
+  > tracker first asking whether they want it. Unsolicited setup PRs
+  > are noise for maintainers.
+- [ ] [README](../blob/main/README.md) updated with the new language. Specifically:
+  - Add a row per token to the **Supported tokens** table, matching the format of the existing Python / JavaScript / TypeScript rows (token in backticks, source tool, language column with the new language name).
+  - Add the file extension(s) to the **Supported file extensions** list.
+  - Keep alphabetical / logical grouping consistent with existing entries.
+
+## Notes
+
+(edge cases, tooling overlap, anything maintainers should know)

--- a/.github/ISSUE_TEMPLATE/showcase_request.md
+++ b/.github/ISSUE_TEMPLATE/showcase_request.md
@@ -1,0 +1,118 @@
+---
+name: Verify and release a language
+about: Promote a language from `experimental` to `released` by testing it on a real-world project.
+title: "lang: verify and release <language> (<project>)"
+labels: ["enhancement", "showcase", "good first issue"]
+---
+
+This issue covers promoting a language from `experimental` to
+`released`. It is a follow-up to a merged *Add a language* issue and
+PR; do not open it for languages that have not yet shipped at the
+`experimental` tier.
+
+> **Open to any contributor.** You do not need to be the person who
+> shipped the language's `experimental` PR — anyone can pick this up.
+> If the original language contributor used the tip in the *Add a
+> language* sanity-check step, they may already have a fork ready and
+> may want to claim this; if you are not them, comment here before
+> starting work to avoid duplicate effort.
+
+> **One showcase per contributor.** Like *Add a language*, this is a
+> well-scoped first contribution and we keep it open for newcomers. If
+> you have already had a showcase PR merged, please do not open
+> another one.
+
+The work has two parts, in order:
+
+1. A PR to [`shamefile-showcase`](https://github.com/BKDDFS/shamefile-showcase)
+   adding the generated `shamefile.yaml` and a short metadata README
+   for this language.
+2. A PR to this repo moving the language from the README's
+   *Experimental tokens* table into *Supported tokens*, with a link to
+   the merged showcase entry.
+
+The showcase repo stores **only `shamefile.yaml` files and metadata** —
+no source code. The upstream project URL and commit SHA are recorded so
+anyone can clone the original codebase for full context.
+
+## Target
+
+- Language:
+- Original language issue / PR:
+- Upstream project (URL):
+- Upstream project commit SHA:
+
+## Pre-flight checks
+
+- [ ] The language is already merged in this repo at the `experimental`
+  tier (row exists in the README's *Experimental tokens* table).
+- [ ] The chosen upstream project is actively maintained, has a
+  recognizable footprint (popular framework, library, or application
+  in this language), and is not a niche or abandoned repo.
+- [ ] No other showcase issue or PR is already in flight for this
+  language (search both this repo and
+  [`shamefile-showcase`](https://github.com/BKDDFS/shamefile-showcase)
+  before starting).
+
+## Generate the showcase
+
+- [ ] Clone the upstream project at a specific commit SHA — record it
+  above:
+  ```sh
+  git clone https://github.com/<org>/<repo> /tmp/showcase
+  cd /tmp/showcase && git checkout <sha>
+  ```
+- [ ] Install the latest released `shamefile` and run `shame me .` to
+  generate `shamefile.yaml`.
+- [ ] Fill the `why` field for every entry. AI assistance is acceptable,
+  but add a note to README about that.
+- [ ] Run `shame me . --dry-run` and confirm it exits zero (every entry
+  has a `why`, no drift between code and registry).
+
+## Showcase PR ([`shamefile-showcase`](https://github.com/BKDDFS/shamefile-showcase))
+
+Open a PR to
+[`shamefile-showcase`](https://github.com/BKDDFS/shamefile-showcase)
+following its `CONTRIBUTING.md`. The PR adds a directory under the
+language name with two files:
+
+```
+<language>/<project>/
+├── shamefile.yaml
+└── README.md
+```
+
+The `README.md` must contain:
+
+- [ ] Upstream project URL
+- [ ] Commit SHA used for the scan
+- [ ] Suppression count
+- [ ] Link back to this issue
+- [ ] If AI was used to generate `why` fields
+
+> **Do not open a PR to the upstream project** introducing
+> `shamefile.yaml` to their repo. If you think a project would benefit
+> from shamefile, open an issue (or discussion) in **their** tracker first asking
+> whether they want it. Unsolicited PRs are noise for maintainers.
+
+## Promotion PR (this repo)
+
+Open this PR only after the showcase PR is merged.
+
+- [ ] Remove the language row from the README's *Experimental* table.
+- [ ] Add token rows to the *Supported tokens* table. The
+  *Experimental* table only lists the language name — *Supported tokens*
+  requires one row per token with `Token`, `Tool`, and `Language`
+  columns, matching the format of existing entries (e.g. Python, JS).
+  Find the full list of tokens for this language in
+  [`src/languages.rs`](../blob/main/src/languages.rs) under the
+  `LANGUAGES` array — each token has a trailing comment naming the
+  tool it comes from.
+- [ ] Add a link to the merged showcase entry next to the new
+  *Supported tokens* rows (footnote, separate column, or short note —
+  match whatever convention the README has when this PR is opened).
+- [ ] Link this PR with `Closes #<this-issue>`.
+
+## Notes
+
+(anomalies in the showcase run, anything maintainers should know)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- 1-3 sentences. What changes and why. -->
+
+## Linked issue
+
+<!-- Closes #N (or "Discussion #N" for design follow-ups). -->
+
+## Test plan
+
+<!-- How was this tested? Commands run, manual scenarios checked. -->
+
+- [ ] `cargo test`
+- [ ] `uv run pytest tests/`
+- [ ] `cargo fmt --all --check`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits
+- [ ] Tests added or updated for behavior changes
+- [ ] Docs updated for user-visible changes
+- [ ] One logical change per PR

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+bartekdawidflis@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to shamefile
+
+Thanks for taking the time to look. Contributions are welcome,
+but please read this first so your time isn't wasted.
+
+## Before you write code
+
+- **Bugs:** open an [issue](https://github.com/BKDDFS/shamefile/issues)
+  with a minimal repro.
+- **Features and design questions:** open a
+  [Discussion](https://github.com/BKDDFS/shamefile/discussions) under
+  *Ideas*. Direction is decided there before any code is written.
+- **Already-accepted work:** look for issues labeled `enhancement` or
+  `bug`.
+
+For non-trivial changes, please get agreement on the approach in the
+issue or discussion before opening a PR.
+
+## Development setup
+
+Requirements:
+
+- Rust **1.95.0** (matching CI)
+- Python **3.14** for integration tests
+- [`uv`](https://docs.astral.sh/uv/) for managing Python dependencies
+- [`pre-commit`](https://pre-commit.com/) (recommended)
+
+Clone and install hooks:
+
+```sh
+git clone https://github.com/BKDDFS/shamefile.git
+cd shamefile
+uv sync --all-extras
+pre-commit install
+```
+
+## Build and test
+
+```sh
+cargo build              # build the binary
+cargo test               # Rust unit tests
+uv run pytest .     # Python tests
+```
+
+Run all three before opening a PR. CI runs the full suite on Linux,
+macOS, and Windows.
+
+## Lint and format
+
+```sh
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+uv run ruff check .
+uv run ruff format .
+```
+
+`pre-commit` runs all of these automatically. CI fails on any warning.
+
+## Commits
+
+[Conventional Commits](https://www.conventionalcommits.org/), enforced
+by the `commit-msg` hook and the PR title check:
+
+- `feat: ...` — new user-visible behavior
+- `fix: ...` — bug fix
+- `docs: ...` — documentation only
+- `test: ...` — tests only
+- `refactor: ...` — internal change, no user-visible effect
+- `chore: ...` — tooling, dependencies, release plumbing
+- `ci: ...` — CI configuration
+
+Optional scope: `feat(scanner): ...`. Use the imperative mood ("add X",
+not "added X").
+
+## Pull requests
+
+- One logical change per PR.
+- PR title follows Conventional Commits (the same rule as commit
+  messages — checked by CI).
+- Link the issue you're closing: `Closes #123` in the PR description.
+- Keep the diff focused. Drive-by refactors go in their own PR.
+- Update tests. New behavior without tests is unlikely to land.
+- Update docs if user-visible behavior changes.
+
+## Scope
+
+shamefile detects linter suppressions, demands a written justification,
+and gates on CI. The core loop is intentionally narrow.
+
+That said, ideas outside the current scope are welcome — please raise
+them in a [Discussion](https://github.com/BKDDFS/shamefile/discussions)
+under *Ideas* before writing code, so direction can be agreed on first.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold it. Report unacceptable
+behavior to bartekdawidflis@gmail.com.
+
+## License
+
+By contributing, you agree your contributions are licensed under the
+Apache License 2.0 (see [LICENSE](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ entries:
 - `location` and `token` form the entry's identity.
 - `content` is the verbatim source line — used for reconciliation when code moves.
 - `owner` and `created_at` are populated automatically on first run via `git blame`.
-- `why` is the only field you fill in by hand.
+- `why` is the only field that requires a written justification — from a developer or an AI agent. The PR reviewer decides whether the reason is good enough.
 
 ## Cascade matching
 
@@ -142,6 +142,18 @@ Renaming a file, reformatting a function, or inserting imports above a suppressi
 | `// tslint:disable`, `/* tslint:disable` | TSLint | TS / TSX |
 | `// @ts-ignore`, `/* @ts-ignore` | TypeScript | JS / TS / TSX |
 | `// @ts-expect-error`, `/* @ts-expect-error` | TypeScript | JS / TS / TSX |
+
+### Experimental tokens
+
+New languages added via the [*Add a language*](.github/ISSUE_TEMPLATE/language_request.md)
+template land here first. They have passed the existing test suite and
+a sanity run on a real codebase, but no real-world showcase has been
+contributed yet. Promotion to *Supported tokens* happens through the
+[*Verify and release a language*](.github/ISSUE_TEMPLATE/showcase_request.md) flow.
+
+| Language |
+|---|
+| |
 
 Supported file extensions: `.py`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`.
 

--- a/README.md
+++ b/README.md
@@ -174,4 +174,12 @@ Or as a [pre-commit](https://pre-commit.com) hook:
 
 ## Contributing
 
-**Missing a token for your linter?** [Open an issue](https://github.com/BKDDFS/shamefile/issues) first — let's agree on scope before you write code.
+Contributions are welcome. Where you start depends on what you have:
+
+- **Found a bug?** [Open an issue](https://github.com/BKDDFS/shamefile/issues/new/choose) with a minimal repro.
+- **Idea or design question?** Open a [Discussion under Ideas](https://github.com/BKDDFS/shamefile/discussions/categories/ideas) so direction can be agreed before any code is written.
+- **Usage question or trouble setting things up?** Ask in [Q&A](https://github.com/BKDDFS/shamefile/discussions/categories/q-a).
+- **Want to send a PR?** Read [CONTRIBUTING.md](CONTRIBUTING.md) first — dev setup, build/test/lint commands, commit format.
+- **Security vulnerability?** Use the private [advisory form](https://github.com/BKDDFS/shamefile/security/advisories/new) — see [SECURITY.md](SECURITY.md). **Do not** open a public issue.
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported versions
+
+The latest released version of `shame` is the only supported version.
+Security fixes are released as patch versions on top of the current
+minor.
+
+| Version | Supported |
+|---|---|
+| 0.1.x   | ✅ |
+| < 0.1   | ❌ |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Use one of the following private channels:
+
+1. **Preferred:** GitHub's
+   ["Report a vulnerability"](https://github.com/BKDDFS/shamefile/security/advisories/new)
+   form (creates a private advisory thread).
+2. **Email:** bartekdawidflis@gmail.com.
+
+Please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce, ideally with a minimal example.
+- Affected version(s).
+- Any suggested mitigation, if known.
+
+## Response
+
+Best-effort response within **7 days** acknowledging the report. A
+disclosure timeline and embargo will be agreed before any public
+discussion.
+
+Once a fix is available, a coordinated release follows: patched version,
+GitHub Security Advisory, and (if applicable) a CVE.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` covering dev setup (Rust 1.95.0, `uv`, `pre-commit`), build/test/lint commands matching CI, Conventional Commits, PR rules, and a soft scope statement that points contributors at Discussions for design questions.
- Adopt **Contributor Covenant v2.1** verbatim as `CODE_OF_CONDUCT.md`, with `bartekdawidflis@gmail.com` as the enforcement contact.
- Add `SECURITY.md` with supported-versions table, a private reporting channel (GitHub Security Advisories preferred, email fallback), and a best-effort 7-day acknowledgement target. Private vulnerability reporting has been enabled in repo settings.

## Test plan

- [x] `CONTRIBUTING.md` renders cleanly on GitHub.
- [x] All shell commands listed in `CONTRIBUTING.md` match the workflows in `.github/workflows/test.yml` and `.github/workflows/lint.yml`.
- [x] `CODE_OF_CONDUCT.md` is detected by GitHub (Community Standards page shows it as present).
- [x] `SECURITY.md` is detected by GitHub and the "Report a vulnerability" link in the file resolves to the private advisory form.