### PR TITLE
chore(linguist): exclude e2e_tests from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-tests/** linguist-vendored
+e2e_tests/** linguist-detectable=false


### PR DESCRIPTION
## Summary
- The Python e2e harness is test scaffolding, not application code. Without an explicit `linguist-detectable=false` attribute, GitHub Linguist counts `e2e_tests/` toward repo language stats and makes this Rust CLI appear majority-Python on the repo page.
- Also drops the stale `tests/**` entry — that path no longer exists after the rename in #52.

## Test plan
- [x] `.gitattributes` validates locally
- [ ] After merge, verify GitHub repo language bar shows Rust as primary