### PR TITLE
chore: dogfood shamefile on this repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,6 @@ jobs:
 
       - name: Pytest e2e tests
         run: uv run pytest e2e_tests/ -v -n auto
+
+      - name: Shame self-check
+        run: cargo run -- me . --dry-run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,13 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      - id: shame
+        name: shame (self-check)
+        entry: cargo run -- me . --dry-run
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:

--- a/shamefile.yaml
+++ b/shamefile.yaml
@@ -1,0 +1,184 @@
+# yamllint disable-file
+---
+config: {}
+entries:
+
+  - location: ./e2e_tests/test_registry/test_registry_dry_run.py:129
+    token: '# type: ignore'
+    content: '# - undocumented (# type: ignore not in registry)'
+    created_at: 2026-05-04T19:25:58.105561Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Descriptive text inside a test comment listing failure cases — not an
+      active mypy directive (e2e_tests/ is not type-checked).
+
+  - location: ./e2e_tests/test_registry/test_registry_encoding.py:15
+    token: '# noqa'
+    content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.120905Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_encoding.py:28
+    token: '# noqa'
+    content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.137991Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_format_fields.py:20
+    token: '# noqa'
+    content: 'assert single_entry["token"] == "# noqa"  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.154863Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_ordering.py:7
+    token: '# noqa'
+    content: 'token="# noqa",  # noqa: S107'
+    created_at: 2026-05-04T19:25:58.169397Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S107 false positive: default arg `token=` is a linter suppression
+      token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_ordering.py:77
+    token: '# type: ignore'
+    content: '# Manually create registry with # type: ignore before'
+    created_at: 2026-05-04T19:25:58.185755Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Descriptive text inside a test comment — not an active mypy directive
+      (e2e_tests/ is not type-checked).
+
+  - location: ./e2e_tests/test_registry/test_registry_ordering.py:83
+    token: '# noqa'
+    content: 'token="# type: ignore",  # noqa: S106'
+    created_at: 2026-05-04T19:25:58.200521Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S106 false positive: keyword arg `token=` carries a linter
+      suppression token name (`# type: ignore`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_ordering.py:89
+    token: '# noqa'
+    content: 'token="# noqa",  # noqa: S106'
+    created_at: 2026-05-04T19:25:58.215772Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S106 false positive: keyword arg `token=` carries a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_shame_vector.py:122
+    token: '# noqa'
+    content: 'noqa_entry = next(e for e in entries if e["token"] == "# noqa")  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.230611Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_shame_vector.py:123
+    token: '# noqa'
+    content: 'type_ignore_entry = next(e for e in entries if e["token"] == "# type: ignore")  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.245716Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# type: ignore`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_tracking.py:65
+    token: '# noqa'
+    content: 'assert type_ignore_entry["token"] == "# type: ignore"  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.260904Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# type: ignore`), not a credential.
+
+  - location: ./e2e_tests/test_registry/test_registry_tracking.py:149
+    token: '# noqa'
+    content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.277291Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_shame_fix.py:22
+    token: '# noqa'
+    content: 'type_ignore = next(e for e in entries if e["token"] == "# type: ignore")  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.290890Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# type: ignore`), not a credential.
+
+  - location: ./e2e_tests/test_shame_fix.py:34
+    token: '# noqa'
+    content: 'noqa = next(e for e in entries if e["token"] == "# noqa")  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.303204Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_shame_next.py:157
+    token: '# noqa'
+    content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.318687Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_token_detection/test_common.py:16
+    token: '# noqa'
+    content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.334925Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_token_detection/test_common.py:44
+    token: '# noqa'
+    content: 'assert any(e["token"] == "nosec" for e in registry["entries"])  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.352059Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`nosec`), not a credential.
+
+  - location: ./e2e_tests/test_token_detection/test_common.py:69
+    token: '# noqa'
+    content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.369602Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_token_detection/test_python_token_detection.py:40
+    token: '# noqa'
+    content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.382735Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.
+
+  - location: ./e2e_tests/test_token_detection/test_python_token_detection.py:52
+    token: '# noqa'
+    content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
+    created_at: 2026-05-04T19:25:58.395659Z
+    owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
+    why: >-
+      Bandit S105 false positive: dict key 'token' compared with a linter
+      suppression token name (`# noqa`), not a credential.


### PR DESCRIPTION
## Summary
- Run `shame me .` against this repo's own `e2e_tests/`, register all 20 detected suppressions in a new top-level `shamefile.yaml`, and document every entry.
- Wire `shame me . --dry-run` into pre-commit (so a missing/undocumented suppression blocks the commit before it lands) and into CI (so it can't be merged without a green build).
- Establishes the project as its own first user.

## Justification audit
All 20 entries fall into three buckets, every `why` references the actual Bandit/mypy mechanic:
- **15× S105** — Bandit's `hardcoded-password-string` heuristic flags any `*token*` variable assigned/compared with a string. Here `entries[i]["token"]` holds a linter-directive name (`# noqa`, `# type: ignore`, `nosec`), not a credential.
- **2× S106** — same heuristic, keyword arg `token="# noqa"` / `token="# type: ignore"` in test fixture calls.
- **1× S107** — same heuristic, default arg `token="# noqa"` in `make_entry`.
- **2× `# type: ignore`** — token text appears as descriptive content inside test comments. `e2e_tests/` is not type-checked (no mypy/pyright/pytype/pyre config anywhere in the repo).

## Test plan
- [x] `cargo run -- me . --dry-run` — all checks pass locally
- [x] pre-commit hook runs and passes (verified during this commit)
- [ ] CI `Shame self-check` step passes on PR