### PR TITLE
fix(registry): emit date-only timestamps in shamefile.yaml

### DIFF
--- a/e2e_tests/test_registry/test_registry_format_fields.py
+++ b/e2e_tests/test_registry/test_registry_format_fields.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 import yaml
@@ -31,12 +31,12 @@ def test_entry_has_empty_why_on_creation(single_entry):
 
 
 def test_entry_has_recent_created_at(single_entry):
-    """Entry created_at should be a recent UTC timestamp."""
+    """Entry created_at should be today's UTC date."""
     created_at = single_entry["created_at"]
-    now = datetime.now(UTC)
+    today = datetime.now(UTC).date()
 
-    assert isinstance(created_at, datetime)
-    assert now - created_at < timedelta(minutes=5)
+    assert isinstance(created_at, date)
+    assert today - created_at <= timedelta(days=1)
 
 
 def test_entry_has_content(single_entry):

--- a/e2e_tests/test_registry/test_registry_yaml_edge_cases.py
+++ b/e2e_tests/test_registry/test_registry_yaml_edge_cases.py
@@ -150,7 +150,8 @@ def test_wrong_type_in_field_exits_with_error(tmp_path):
 
 
 def test_non_utc_timezone_normalized_to_utc(tmp_path):
-    """Non-UTC timezone offset in created_at is parsed and normalized to UTC by chrono."""
+    """Non-UTC timezone offsets that cross midnight UTC are normalized to the UTC date."""
+    # 2024-01-16T02:00+05:30 → 2024-01-15T20:30Z, so the saved date should be 2024-01-15.
     (tmp_path / "test.py").write_text("x = 1  # noqa\n", encoding="utf-8")
     (tmp_path / "shamefile.yaml").write_text(
         "config: {}\n"
@@ -159,7 +160,7 @@ def test_non_utc_timezone_normalized_to_utc(tmp_path):
         "    token: '# noqa'\n"
         "    content: 'x = 1  # noqa'\n"
         "    owner: 'Alice'\n"
-        "    created_at: '2024-01-15T10:00:00+05:30'\n"
+        "    created_at: '2024-01-16T02:00:00+05:30'\n"
         "    why: 'Legacy'\n",
         encoding="utf-8",
     )
@@ -169,8 +170,7 @@ def test_non_utc_timezone_normalized_to_utc(tmp_path):
     assert result.returncode == 0
     saved = yaml.safe_load((tmp_path / "shamefile.yaml").read_text(encoding="utf-8"))
     created_at = str(saved["entries"][0]["created_at"])
-    assert "2024-01-15" in created_at
-    assert "04:30" in created_at
+    assert created_at == "2024-01-15"
 
 
 def test_yaml_anchor_merge_key_fails_with_clear_error(tmp_path):

--- a/shamefile.yaml
+++ b/shamefile.yaml
@@ -6,7 +6,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_dry_run.py:129
     token: '# type: ignore'
     content: '# - undocumented (# type: ignore not in registry)'
-    created_at: 2026-05-04T19:25:58.105561Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Descriptive text inside a test comment listing failure cases — not an
@@ -15,7 +15,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_encoding.py:15
     token: '# noqa'
     content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.120905Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -24,7 +24,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_encoding.py:28
     token: '# noqa'
     content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.137991Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -33,7 +33,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_format_fields.py:20
     token: '# noqa'
     content: 'assert single_entry["token"] == "# noqa"  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.154863Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -42,7 +42,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_ordering.py:7
     token: '# noqa'
     content: 'token="# noqa",  # noqa: S107'
-    created_at: 2026-05-04T19:25:58.169397Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S107 false positive: default arg `token=` is a linter suppression
@@ -51,7 +51,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_ordering.py:77
     token: '# type: ignore'
     content: '# Manually create registry with # type: ignore before'
-    created_at: 2026-05-04T19:25:58.185755Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Descriptive text inside a test comment — not an active mypy directive
@@ -60,7 +60,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_ordering.py:83
     token: '# noqa'
     content: 'token="# type: ignore",  # noqa: S106'
-    created_at: 2026-05-04T19:25:58.200521Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S106 false positive: keyword arg `token=` carries a linter
@@ -69,7 +69,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_ordering.py:89
     token: '# noqa'
     content: 'token="# noqa",  # noqa: S106'
-    created_at: 2026-05-04T19:25:58.215772Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S106 false positive: keyword arg `token=` carries a linter
@@ -78,7 +78,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_shame_vector.py:122
     token: '# noqa'
     content: 'noqa_entry = next(e for e in entries if e["token"] == "# noqa")  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.230611Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -87,7 +87,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_shame_vector.py:123
     token: '# noqa'
     content: 'type_ignore_entry = next(e for e in entries if e["token"] == "# type: ignore")  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.245716Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -96,7 +96,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_tracking.py:65
     token: '# noqa'
     content: 'assert type_ignore_entry["token"] == "# type: ignore"  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.260904Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -105,7 +105,7 @@ entries:
   - location: ./e2e_tests/test_registry/test_registry_tracking.py:149
     token: '# noqa'
     content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.277291Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -114,7 +114,7 @@ entries:
   - location: ./e2e_tests/test_shame_fix.py:22
     token: '# noqa'
     content: 'type_ignore = next(e for e in entries if e["token"] == "# type: ignore")  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.290890Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -123,7 +123,7 @@ entries:
   - location: ./e2e_tests/test_shame_fix.py:34
     token: '# noqa'
     content: 'noqa = next(e for e in entries if e["token"] == "# noqa")  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.303204Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -132,7 +132,7 @@ entries:
   - location: ./e2e_tests/test_shame_next.py:157
     token: '# noqa'
     content: 'assert entries[0]["token"] == "# noqa"  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.318687Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -141,7 +141,7 @@ entries:
   - location: ./e2e_tests/test_token_detection/test_common.py:16
     token: '# noqa'
     content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.334925Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -150,7 +150,7 @@ entries:
   - location: ./e2e_tests/test_token_detection/test_common.py:44
     token: '# noqa'
     content: 'assert any(e["token"] == "nosec" for e in registry["entries"])  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.352059Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -159,7 +159,7 @@ entries:
   - location: ./e2e_tests/test_token_detection/test_common.py:69
     token: '# noqa'
     content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.369602Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -168,7 +168,7 @@ entries:
   - location: ./e2e_tests/test_token_detection/test_python_token_detection.py:40
     token: '# noqa'
     content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.382735Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter
@@ -177,7 +177,7 @@ entries:
   - location: ./e2e_tests/test_token_detection/test_python_token_detection.py:52
     token: '# noqa'
     content: 'assert any(e["token"] == "# noqa" for e in registry["entries"])  # noqa: S105'
-    created_at: 2026-05-04T19:25:58.395659Z
+    created_at: 2026-05-04
     owner: Bartlomiej Flis <bartekdawidflis@gmail.com>
     why: >-
       Bandit S105 false positive: dict key 'token' compared with a linter

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -28,7 +28,10 @@ pub struct Entry {
     pub location: String,
     pub token: String,
     pub content: String,
-    #[serde(deserialize_with = "deserialize_created_at")]
+    #[serde(
+        deserialize_with = "deserialize_created_at",
+        serialize_with = "serialize_created_at"
+    )]
     pub created_at: DateTime<Utc>,
     pub owner: String,
     #[serde(deserialize_with = "deserialize_why")]
@@ -51,6 +54,13 @@ where
     Err(serde::de::Error::custom(format!(
         "invalid created_at: '{s}' — expected RFC 3339 (e.g. '2024-01-15T00:00:00Z') or date (e.g. '2024-01-15')"
     )))
+}
+
+fn serialize_created_at<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&dt.format("%Y-%m-%d").to_string())
 }
 
 fn deserialize_why<'de, D>(deserializer: D) -> Result<String, D::Error>


### PR DESCRIPTION
## Summary
- `Utc::now()` was serialized through chrono's default RFC3339 formatter, producing sub-microsecond precision like `2026-05-04T19:25:58.105561Z`. That precision is meaningless for a suppression audit trail and makes every touched entry produce a noisy diff.
- Add a `serialize_with` that emits `YYYY-MM-DD`. Deserializer already accepts both date-only and full RFC3339, so existing registries continue to load — the next `shame me` run normalizes their timestamps automatically.
- Apply the normalization to this repo's own `shamefile.yaml` so the demo registry reflects the new format.

## Compat
- **Read path**: unchanged — both `2024-01-15` and `2024-01-15T10:30:00Z` parse, including non-UTC offsets which are normalized by chrono.
- **Write path**: always emits `YYYY-MM-DD`. On first `shame me` after upgrade, users see a one-time diff converting all timestamps to dates. After that, no churn.
- Patch-level change in 0.x — release-plz should pick this up as 0.1.2.

## Test plan
- [x] `cargo test` — 62 passed
- [x] `uv run pytest e2e_tests/ -n auto` — 283 passed
- [x] `test_entry_has_recent_created_at` updated to expect `date` instead of `datetime` (PyYAML loads `YYYY-MM-DD` as `datetime.date`)
- [x] `test_non_utc_timezone_normalized_to_utc` rewritten to verify a midnight-crossing offset normalizes the **date** (since the time component is no longer visible)
- [x] `shame me . --dry-run` self-check passes