### PR TITLE
chore(ci): populate release-plz GitHub release body

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,6 +3,14 @@
 changelog_update = false
 git_release_enable = true
 git_release_draft = true
+git_release_body = """
+{% for group, group_commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in group_commits %}
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}
+{%- endfor %}
+{% endfor %}
+"""
 
 # publish-cargo.yml handles that
 publish = false


### PR DESCRIPTION
## Summary
- The repo opted out of \`CHANGELOG.md\` (\`changelog_update = false\`) intending **GitHub Releases** to be the changelog, but no \`git_release_body\` template was set — so release-plz emitted empty release bodies.
- Add a Tera template that groups commits by conventional-commit type and renders each as a bullet with scope and breaking-change marker.

## Effect
After merge, the next release-plz PR will populate the GitHub release body with sections like:

\`\`\`md
### Features
- *(registry)* Track owner from git blame

### Bug Fixes
- Emit date-only timestamps in shamefile.yaml
\`\`\`

## Test plan
- [x] \`release-plz.toml\` syntax-valid (TOML parses)
- [ ] After merge: next release-plz PR shows non-empty body. Verify in PR description before tagging.