### PR TITLE
fix: drop MSRV to 1.88 and tighten README sample accuracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shamefile"
 version = "0.1.2"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.88"
 license = "Apache-2.0"
 description = "Turn linter suppressions from silent technical debt into reviewable, documented decisions."
 repository = "https://github.com/BKDDFS/shamefile"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ Or as a [pre-commit](https://pre-commit.com) hook:
     - id: shamefile
 ```
 
+## Show shamefile in your README
+
+[![shamefile](https://img.shields.io/badge/shamefile-on_board-b81414)](https://github.com/BKDDFS/shamefile)
+
+```markdown
+[![shamefile](https://img.shields.io/badge/shamefile-on_board-b81414)](https://github.com/BKDDFS/shamefile)
+```
+
 ## Roadmap
 
 - **MCP server** — native integration for LLM-based PR authors (avoids loading the full registry into agent context)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ result = parse_legacy_api(raw)  # type: ignore
 
 ```
 $ shame me .
+Creating new registry at /home/user/myproject/shamefile.yaml
 Scanning . for suppressions...
 Added 1 new entries to /home/user/myproject/shamefile.yaml
 1 suppressions need documentation (why).
@@ -66,6 +67,7 @@ $ shame next
 ./src/api.py:42
     |
   42| result = parse_legacy_api(raw)  # type: ignore
+    |                                 ^^^^^^^^^^^^^^
 
 Fix with:
   shame next "<reason>"
@@ -113,7 +115,7 @@ entries:
 - location: ./src/api.py:42
   token: '# type: ignore'
   content: 'result = parse_legacy_api(raw)  # type: ignore'
-  created_at: 2026-04-17T21:15:05Z
+  created_at: 2026-04-17
   owner: Anna Nowak <anna@example.com>
   why: 'legacy API returns untyped dict; types module in progress'
 ```

--- a/README.md
+++ b/README.md
@@ -191,14 +191,6 @@ Or as a [pre-commit](https://pre-commit.com) hook:
     - id: shamefile
 ```
 
-## Show shamefile in your README
-
-[![shamefile](https://img.shields.io/badge/shamefile-on_board-b81414)](https://github.com/BKDDFS/shamefile)
-
-```markdown
-[![shamefile](https://img.shields.io/badge/shamefile-on_board-b81414)](https://github.com/BKDDFS/shamefile)
-```
-
 ## Roadmap
 
 - **MCP server** — native integration for LLM-based PR authors (avoids loading the full registry into agent context)


### PR DESCRIPTION
## Summary

- Lower `rust-version` from 1.95 to 1.88 — the previous floor was over-declared. The codebase only needs `let_chains` (stable since 1.88) on top of edition 2024 (stable since 1.85), so anyone on the previous two stable toolchains was being blocked from `cargo install shamefile` for no reason.
- Align README workflow samples with what the CLI actually prints today:
  - Show `Creating new registry at ...` on the first run.
  - Render the underline `shame next` emits beneath the matched token.
  - Use the date-only `created_at` format the registry currently writes (instead of an RFC 3339 string that never appears on disk).

## Test plan

- [x] `cargo build` on default stable toolchain still passes.
- [x] Confirmed via `cargo +1.85.0 build` that the only thing keeping us above 1.85 is `let_chains` in `src/registry.rs:49-50`, which is stable in 1.88.
- [x] Smoke-tested all three install channels against the current published `0.1.2` (npm, PyPI via `uv pip`, crates.io); end-to-end `shame me` / `shame next` / `shame me --dry-run` flow matches the README sample after these doc fixes.
- [ ] Wait for CI to confirm tests + lints pass.