### PR TITLE
fix: release-plz, pre-launch FAQ, contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,10 @@ but please read this first so your time isn't wasted.
 - **Already-accepted work:** look for issues labeled `enhancement` or
   `bug`.
 
+Issues with an assignee are already being worked on. Pick an unassigned
+issue (especially those labeled `help wanted`), or comment on the issue
+to coordinate before starting non-trivial work.
+
 For non-trivial changes, please get agreement on the approach in the
 issue or discussion before opening a PR.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,32 @@ Or as a [pre-commit](https://pre-commit.com) hook:
 - **Custom git merge driver** — auto-resolve `shamefile.yaml` conflicts on parallel PRs
 - **Additional language grammars** — Rust, Go, Java, Kotlin, C# via tree-sitter
 - **Custom entry fields** — attach `ticket`, `reviewer`, or `deadline` metadata to suppressions
+- **Native exclusion config** — first-class `exclude:` patterns in `shamefile.yaml` for checked-in vendored or generated code that bypasses the default `.gitignore` discovery
+
+## FAQ
+
+**Why not just write the reason inline, like `# noqa: F401  # legacy import`?**
+
+- **Reviewers don't see it.** A `# noqa` buried in one of seven changed files rarely gets pushback. `shamefile.yaml` puts every suppression in the PR into one diff — the reviewer sees the full cost as a single list, with author and `why` per entry.
+- **Nothing forces a reason.** Linters accept any string after the token, or none. `shame me . --dry-run` fails the build until every entry has a non-empty `why`. This matters most for AI coding agents, which lose the suppression's context the moment the session ends — the registry forces them to write the reason to disk while it still exists.
+- **Inline is a bad trade-off.** A short reason carries no information; a useful one drowns the line of code it is attached to. The registry keeps source readable and justifications detailed.
+
+**What stops developers from writing `why: 'TODO'` and moving on?**
+
+The tool guarantees a string is written; the reviewer judges whether it is a real reason. If `why: 'TODO'` passes review, that is an organisational gap, not a tool gap — but the registry makes the gap visible: every lazy entry is one `grep` away, by author and date. Before `shamefile`, the same shortcut was hidden inside whichever file it lived in.
+
+**Won't `shamefile.yaml` become a merge conflict magnet on parallel PRs?**
+
+The registry is sorted by `(location, token)`, so suppressions added in unrelated parts of the codebase land in different regions of the file — most parallel PRs do not collide. When they do, `shame me` is idempotent: after a merge, running it on the resolved tree deterministically reconciles entries from source, so `git checkout --theirs shamefile.yaml && shame me .` is the escape hatch. A custom git merge driver that resolves automatically is on the Roadmap. This is the same trade-off every shared-file tool (lockfiles, changelogs, schema migrations) has accepted in exchange for single-source-of-truth visibility.
+
+**What about generated, vendored, or third-party code?**
+
+A repo's typical generated/vendored content is excluded for free:
+
+- `.gitignore` and `.ignore` files are respected (handled by the same engine `ripgrep` uses), so `node_modules/`, `target/`, `dist/`, `__pycache__/` etc. are skipped without configuration.
+- Only `.py / .js / .jsx / .mjs / .cjs / .ts / .tsx` are scanned, so vendored content in any other language is silently ignored.
+
+A first-class `exclude:` config in `shamefile.yaml` is on the [Roadmap](#roadmap).
 
 ## Contributing
 

--- a/e2e_tests/test_registry/test_registry_yaml_edge_cases.py
+++ b/e2e_tests/test_registry/test_registry_yaml_edge_cases.py
@@ -151,7 +151,6 @@ def test_wrong_type_in_field_exits_with_error(tmp_path):
 
 def test_non_utc_timezone_normalized_to_utc(tmp_path):
     """Non-UTC timezone offsets that cross midnight UTC are normalized to the UTC date."""
-    # 2024-01-16T02:00+05:30 → 2024-01-15T20:30Z, so the saved date should be 2024-01-15.
     (tmp_path / "test.py").write_text("x = 1  # noqa\n", encoding="utf-8")
     (tmp_path / "shamefile.yaml").write_text(
         "config: {}\n"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,16 +1,7 @@
 [workspace]
-# GitHub Releases are the changelog
-changelog_update = false
+changelog_update = true
 git_release_enable = true
 git_release_draft = true
-git_release_body = """
-{% for group, group_commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
-{% for commit in group_commits %}
-- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}
-{%- endfor %}
-{% endfor %}
-"""
 
 # publish-cargo.yml handles that
 publish = false


### PR DESCRIPTION
## Summary

- **README:** add FAQ section answering common objections (inline reasons, lazy `why`, merge conflicts, generated code) and drop the bootstrap-workaround note pending a real `--bootstrap` design (tracked in #61)
- **release-plz.toml:** flip `changelog_update = true` and remove the custom `git_release_body` template so `CHANGELOG.md` is the single source of truth — release-plz now populates the release-PR body and the GitHub Release body from the same content
- **CONTRIBUTING.md:** clarify the issue-assignment convention so contributors know to skip assigned issues or comment to coordinate

## Test plan

- [ ] CI green on this branch
- [ ] After merge, next release-plz PR shows a populated changelog block in the body