### PR TITLE
feat(cli): add `shame remove` command (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=BKDDFS_shamefile&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=BKDDFS_shamefile)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Rust](https://img.shields.io/badge/powered_by-Rust-b81414?logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![shamefile](https://img.shields.io/badge/tracked_with-shamefile-b81414)](https://github.com/BKDDFS/shamefile)
 
 <br clear="left">
 
@@ -35,7 +36,7 @@ A mysterious `# noqa` with no explanation, left by a developer who moved on year
 
 **Scan** — `shame me .` walks your project, finds every suppression token, and syncs the central `shamefile.yaml`. New suppressions are registered with auto-filled metadata (owner from `git blame`, timestamp, source line). Stale entries are removed. The command fails if any entry lacks a `why`.
 
-**Document** — `shame next` shows the first undocumented suppression, with the exact source line highlighted. Provide the reason inline (`shame next "<reason>"`), or target a specific entry with `shame fix <location> <token> --why "<reason>"`.
+**Document** — `shame next` shows the first undocumented suppression, with the exact source line highlighted. Provide the reason inline (`shame next "<reason>"`), or target a specific entry with `shame fix <location> <token> --why "<reason>"`. To delete a stale entry without editing the YAML by hand, use `shame remove <location> <token>` (alias `shame rm`).
 
 The same interface works for a developer opening a PR and for an AI agent iterating through gaps one at a time — without having to read the full registry into context.
 

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -118,6 +118,17 @@ def run_shame_fix(cwd, *args):
     )
 
 
+def run_shame_remove(cwd, *args):
+    """Run 'shame remove' in a specific working directory."""
+    return subprocess.run(
+        [BINARY_PATH, "remove", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        check=False,
+    )
+
+
 def git_init(path, user="Alice", email="alice@test.com"):
     """Initialize a git repo with user config. Returns path."""
     subprocess.run(["git", "init"], cwd=path, capture_output=True, check=True)

--- a/e2e_tests/features/shame_remove.feature
+++ b/e2e_tests/features/shame_remove.feature
@@ -1,0 +1,83 @@
+Feature: shame remove
+  shame remove <location> <token> deletes a single entry from shamefile.yaml,
+  identifying it by the same (location, token) pair used by shame fix.
+
+  Together with shame next (read one) and shame fix (update one), shame remove
+  closes the entry-level CRUD surface so humans and AI agents can delete an
+  outdated entry without ever reading the full registry into context.
+
+  Scenario: Removes the entry matching location and token
+    Given a project with five suppressions
+    When I run shame remove "./test.py:2" "# type: ignore"
+    Then the command exits with code 0
+    And stdout contains "Removed"
+    And shamefile.yaml has 4 entries
+    And shamefile.yaml does not contain token "# type: ignore"
+
+  Scenario: Leaves other entries untouched
+    Given a project with five suppressions
+    When I run shame remove "./test.py:2" "# type: ignore"
+    Then shamefile.yaml contains token "# noqa"
+    And shamefile.yaml contains token "nosec"
+    And shamefile.yaml contains token "# pragma: no cover"
+    And shamefile.yaml contains token "# fmt: off"
+
+  Scenario: Preserves why on other entries
+    Given a project with five suppressions
+    And the entry "./test.py:1" "# noqa" has why "kept reason"
+    When I run shame remove "./test.py:2" "# type: ignore"
+    Then the entry "./test.py:1" "# noqa" has why "kept reason"
+
+  Scenario: Confirmation includes token and location
+    Given a project with five suppressions
+    When I run shame remove "./test.py:2" "# type: ignore"
+    Then stdout contains "# type: ignore"
+    And stdout contains "./test.py:2"
+
+  Scenario: Wrong location fails with no-entry-found error
+    Given a project with five suppressions
+    When I run shame remove "./nonexistent.py:1" "# noqa"
+    Then the command exits with code 1
+    And stderr contains "No entry found"
+
+  Scenario: Wrong token fails with no-entry-found error
+    Given a project with five suppressions
+    When I run shame remove "./test.py:1" "# type: ignore"
+    Then the command exits with code 1
+    And stderr contains "No entry found"
+
+  Scenario: No-match leaves registry file unchanged
+    Given a project with five suppressions
+    And the registry contents are captured
+    When I run shame remove "./nonexistent.py:1" "# noqa"
+    Then the registry contents are unchanged
+
+  Scenario: Missing token argument fails with clap usage error
+    Given a project with five suppressions
+    When I run shame remove "./test.py:1" without the token argument
+    Then the command exits with code 2
+
+  Scenario: Shows count of undocumented entries remaining
+    Given a project with five suppressions
+    When I run shame remove "./test.py:2" "# type: ignore"
+    Then stdout contains "4 entries remaining"
+
+  Scenario: Removing the only undocumented entry reports all documented
+    Given a project with one undocumented suppression
+    When I run shame remove "./test.py:1" "# noqa"
+    Then the command exits with code 0
+    And stdout contains "All entries documented"
+
+  Scenario: Without registry fails with helpful message
+    Given a project with no registry
+    When I run shame remove "./test.py:1" "# noqa"
+    Then the command exits with code 1
+    And stderr contains "Registry not found"
+
+  Scenario: rm is an alias for remove
+    Given a project with five suppressions
+    When I run shame rm "./test.py:2" "# type: ignore"
+    Then the command exits with code 0
+    And stdout contains "Removed"
+    And shamefile.yaml has 4 entries
+    And shamefile.yaml does not contain token "# type: ignore"

--- a/e2e_tests/test_shame_remove.py
+++ b/e2e_tests/test_shame_remove.py
@@ -1,0 +1,150 @@
+"""BDD tests for shame remove — feature file: features/shame_remove.feature."""
+
+import subprocess
+
+import yaml
+from conftest import BINARY_PATH, run_shame_fix, run_shame_remove, run_shamefile
+from pytest_bdd import given, parsers, scenarios, then, when
+
+scenarios("features/shame_remove.feature")
+
+FIVE_SUPPRESSIONS = (
+    "a = 1  # noqa\nb = 2  # type: ignore\nc = 3  # nosec\n"
+    "d = 4  # pragma: no cover\ne = 5  # fmt: off\n"
+)
+
+
+# --- Given ---
+
+
+@given("a project with five suppressions", target_fixture="project")
+def project_with_five_suppressions(tmp_path):
+    """Create a project with five different suppressions and run initial shame me."""
+    (tmp_path / "test.py").write_text(FIVE_SUPPRESSIONS, encoding="utf-8")
+    run_shamefile(tmp_path)
+    return {"path": tmp_path, "result": None, "registry_snapshot": None}
+
+
+@given("a project with one undocumented suppression", target_fixture="project")
+def project_with_one_suppression(tmp_path):
+    """Create a project with a single # noqa suppression."""
+    (tmp_path / "test.py").write_text("x = 1  # noqa\n", encoding="utf-8")
+    run_shamefile(tmp_path)
+    return {"path": tmp_path, "result": None, "registry_snapshot": None}
+
+
+@given("a project with no registry", target_fixture="project")
+def project_with_no_registry(tmp_path):
+    """Create an empty project where shamefile.yaml does not exist."""
+    return {"path": tmp_path, "result": None, "registry_snapshot": None}
+
+
+@given(parsers.parse('the entry "{location}" "{token}" has why "{why}"'))
+def set_entry_why(project, location, token, why):
+    """Document a specific entry by running shame fix."""
+    run_shame_fix(project["path"], location, token, "--why", why)
+
+
+@given("the registry contents are captured")
+def capture_registry(project):
+    """Snapshot the registry file before invoking the command under test."""
+    project["registry_snapshot"] = (project["path"] / "shamefile.yaml").read_text(encoding="utf-8")
+
+
+# --- When ---
+
+
+@when(parsers.parse('I run shame remove "{location}" "{token}"'))
+def run_remove(project, location, token):
+    """Invoke `shame remove` for the given (location, token) pair."""
+    project["result"] = run_shame_remove(project["path"], location, token)
+
+
+@when(parsers.parse('I run shame rm "{location}" "{token}"'))
+def run_rm(project, location, token):
+    """Invoke the `rm` alias of `shame remove`."""
+    project["result"] = subprocess.run(
+        [BINARY_PATH, "rm", location, token],
+        capture_output=True,
+        text=True,
+        cwd=str(project["path"]),
+        check=False,
+    )
+
+
+@when(parsers.parse('I run shame remove "{location}" without the token argument'))
+def run_remove_missing_token(project, location):
+    """Invoke `shame remove` without the required positional token to trigger a clap error."""
+    project["result"] = subprocess.run(
+        [BINARY_PATH, "remove", location],
+        capture_output=True,
+        text=True,
+        cwd=str(project["path"]),
+        check=False,
+    )
+
+
+# --- Then ---
+
+
+@then(parsers.parse("the command exits with code {code:d}"))
+def check_exit_code(project, code):
+    """Verify the last command's exit code."""
+    assert project["result"].returncode == code, (
+        f"exit code {project['result'].returncode}\n"
+        f"stdout: {project['result'].stdout}\n"
+        f"stderr: {project['result'].stderr}"
+    )
+
+
+@then(parsers.parse('stdout contains "{text}"'))
+def check_stdout_contains(project, text):
+    """Verify stdout contains the given substring."""
+    assert text in project["result"].stdout, f"{text!r} not in stdout: {project['result'].stdout!r}"
+
+
+@then(parsers.parse('stderr contains "{text}"'))
+def check_stderr_contains(project, text):
+    """Verify stderr contains the given substring."""
+    assert text in project["result"].stderr, f"{text!r} not in stderr: {project['result'].stderr!r}"
+
+
+@then(parsers.parse("shamefile.yaml has {count:d} entries"))
+def check_entry_count(project, count):
+    """Verify the registry contains the expected number of entries."""
+    entries = yaml.safe_load((project["path"] / "shamefile.yaml").read_text())["entries"]
+    assert len(entries) == count, f"expected {count} entries, got {len(entries)}"
+
+
+@then(parsers.parse('shamefile.yaml contains token "{token}"'))
+def check_token_present(project, token):
+    """Verify the registry contains an entry with the given token."""
+    entries = yaml.safe_load((project["path"] / "shamefile.yaml").read_text())["entries"]
+    tokens = [e["token"] for e in entries]
+    assert token in tokens, f"token {token!r} not in {tokens!r}"
+
+
+@then(parsers.parse('shamefile.yaml does not contain token "{token}"'))
+def check_token_absent(project, token):
+    """Verify the registry has no entry with the given token."""
+    entries = yaml.safe_load((project["path"] / "shamefile.yaml").read_text())["entries"]
+    tokens = [e["token"] for e in entries]
+    assert token not in tokens, f"unexpected token {token!r} still in {tokens!r}"
+
+
+@then(parsers.parse('the entry "{location}" "{token}" has why "{why}"'))
+def check_entry_why(project, location, token, why):
+    """Verify the why field of the entry identified by (location, token)."""
+    entries = yaml.safe_load((project["path"] / "shamefile.yaml").read_text())["entries"]
+    entry = next((e for e in entries if e["location"] == location and e["token"] == token), None)
+    assert entry is not None, f"no entry at {location} with token {token!r}"
+    assert entry["why"] == why, f"entry why = {entry['why']!r}, expected {why!r}"
+
+
+@then("the registry contents are unchanged")
+def check_registry_unchanged(project):
+    """Verify the registry file is byte-for-byte identical to the captured snapshot."""
+    snapshot = project["registry_snapshot"]
+    assert snapshot is not None, "registry snapshot was not captured"
+    current = (project["path"] / "shamefile.yaml").read_text(encoding="utf-8")
+    assert current == snapshot, "registry file was modified despite no-match"

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,16 @@ enum Commands {
         #[arg(long)]
         why: String,
     },
+
+    /// Remove a specific suppression entry from the registry
+    #[command(alias = "rm")]
+    Remove {
+        /// Location (e.g. "./src/foo.py:42")
+        location: String,
+
+        /// Token (e.g. "# noqa")
+        token: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -157,6 +167,9 @@ fn main() -> Result<()> {
             why,
         } => {
             handle_fix(&location, &token, &why)?;
+        }
+        Commands::Remove { location, token } => {
+            handle_remove(&location, &token)?;
         }
     }
     Ok(())
@@ -738,6 +751,34 @@ fn handle_next(fix: Option<&str>) -> Result<()> {
             println!("{} more entries need documentation.", remaining - 1);
         }
     }
+
+    Ok(())
+}
+
+fn handle_remove(location: &str, token: &str) -> Result<()> {
+    let config_path = find_registry_path()?;
+    let mut registry = Registry::load(&config_path).context("Failed to load registry")?;
+
+    let entry_idx = registry
+        .entries
+        .iter()
+        .position(|e| e.location == location && e.token == token)
+        .ok_or_else(|| anyhow::anyhow!("No entry found for {} with token '{}'", location, token))?;
+
+    let removed = registry.entries.remove(entry_idx);
+
+    println!("Removed: {} at {}", removed.token, removed.location);
+
+    registry
+        .save(&config_path)
+        .context("Failed to save registry")?;
+
+    let remaining = registry
+        .entries
+        .iter()
+        .filter(|e| e.why.trim().is_empty())
+        .count();
+    print_remaining(remaining);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `shame remove <location> <token>` (alias `shame rm`) — third entry-level CRUD command alongside `next` and `fix`
- Identifies entries by the same `(location, token)` pair used by `shame fix`; exits non-zero with `No entry found` and leaves the registry untouched on no-match
- Closes #48 — humans and AI agents can now delete stale entries without ever opening `shamefile.yaml`, preserving the "never read the full registry" contract
- Drive-by: README gains a `tracked_with-shamefile` self-attribution badge so downstream libraries can advertise shamefile usage

## Notes

Tests live in `e2e_tests/features/shame_remove.feature` with step defs in `test_shame_remove.py`. This is the first BDD coverage for a `shame` subcommand — chosen so the gherkin scenarios survive a future Rust port of the e2e suite. Existing plain-pytest tests for `me`/`next`/`fix` are untouched and can be migrated together later.

## Test plan

- [x] `cargo test` — 62 unit/integration tests pass
- [x] `pytest e2e_tests/` — 295 e2e tests pass (12 new BDD scenarios for `remove` + `rm` alias)
- [x] TDD red-then-green: ran the feature suite against an unimplemented `Remove` variant first to confirm 8/11 scenarios go red on `unrecognized subcommand`, then implemented and re-ran to confirm green
- [x] Pre-commit / pre-push hooks pass (`cargo fmt`, `clippy`, `ruff`)
- [x] Manual smoke: `shame remove ./test.py:2 "# type: ignore"` and `shame rm ./test.py:2 "# type: ignore"` both delete the entry and print `Removed: …`