### PR TITLE
fix: normalize Windows absolute registry paths

### DIFF
--- a/e2e_tests/test_registry/test_registry_stale.py
+++ b/e2e_tests/test_registry/test_registry_stale.py
@@ -1,7 +1,5 @@
 import subprocess
-import sys
 
-import pytest
 import yaml
 from conftest import BINARY_PATH, run_shamefile
 
@@ -285,11 +283,6 @@ def test_absolute_path_entry_detected_as_stale(tmp_path):
     assert "Removing stale entry" in result.stdout
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Windows extended-length path prefix (\\\\?\\) breaks strip_prefix in "
-    "is_entry_in_scope. Tracked in https://github.com/BKDDFS/shamefile/issues/10",
-)
 def test_absolute_path_entry_stale_with_scoped_scan(tmp_path):
     """Entry with absolute path should be stale when its file is under a scanned subdir."""
     src = tmp_path / "src"

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,10 +73,7 @@ fn is_entry_in_scope(
 ) -> bool {
     let entry_file_raw = PathBuf::from(entry.file());
     let entry_file = if entry_file_raw.is_absolute() {
-        entry_file_raw
-            .strip_prefix(registry_dir_canonical)
-            .map(|p| p.to_path_buf())
-            .unwrap_or(entry_file_raw)
+        strip_registry_prefix(&entry_file_raw, registry_dir_canonical).unwrap_or(entry_file_raw)
     } else {
         entry_file_raw
     };
@@ -88,6 +85,53 @@ fn is_entry_in_scope(
         scan_paths_canonical
             .iter()
             .any(|sp| entry_file.starts_with(sp))
+    }
+}
+
+fn strip_registry_prefix(path: &Path, registry_dir_canonical: &Path) -> Option<PathBuf> {
+    path.strip_prefix(registry_dir_canonical)
+        .map(|p| p.to_path_buf())
+        .ok()
+        .or_else(|| strip_registry_prefix_fallback(path, registry_dir_canonical))
+}
+
+#[cfg(windows)]
+fn strip_registry_prefix_fallback(path: &Path, registry_dir_canonical: &Path) -> Option<PathBuf> {
+    let path = strip_windows_verbatim_prefix(path);
+    let registry_dir = strip_windows_verbatim_prefix(registry_dir_canonical);
+    path.strip_prefix(registry_dir)
+        .map(|p| p.to_path_buf())
+        .ok()
+}
+
+#[cfg(not(windows))]
+fn strip_registry_prefix_fallback(_path: &Path, _registry_dir_canonical: &Path) -> Option<PathBuf> {
+    None
+}
+
+#[cfg(windows)]
+fn strip_windows_verbatim_prefix(path: &Path) -> PathBuf {
+    use std::path::{Component, Prefix};
+
+    let mut components = path.components();
+    if let Some(Component::Prefix(prefix)) = components.next() {
+        match prefix.kind() {
+            Prefix::VerbatimDisk(drive) => {
+                let mut normalized = PathBuf::from(format!("{}:", drive as char));
+                normalized.extend(components);
+                normalized
+            }
+            Prefix::VerbatimUNC(server, share) => {
+                let mut normalized = PathBuf::from(r"\\");
+                normalized.push(server);
+                normalized.push(share);
+                normalized.extend(components);
+                normalized
+            }
+            _ => path.to_path_buf(),
+        }
+    } else {
+        path.to_path_buf()
     }
 }
 
@@ -386,10 +430,7 @@ fn handle_normal(
         );
         let entry_file_raw = PathBuf::from(old.file());
         let entry_file_normalized = if entry_file_raw.is_absolute() {
-            entry_file_raw
-                .strip_prefix(registry_dir_canonical)
-                .map(|p| p.to_path_buf())
-                .unwrap_or(entry_file_raw)
+            strip_registry_prefix(&entry_file_raw, registry_dir_canonical).unwrap_or(entry_file_raw)
         } else {
             entry_file_raw
         };
@@ -941,6 +982,21 @@ mod tests {
         let entry = entry("./src/foo.py:1", "# noqa", "");
         let scan_paths = vec![PathBuf::from("./src")];
         let registry_dir = PathBuf::from("/repo");
+        assert!(is_entry_in_scope(
+            &entry,
+            &HashSet::new(),
+            &HashSet::new(),
+            &scan_paths,
+            &registry_dir,
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn is_entry_in_scope_normalizes_windows_verbatim_registry_prefix() {
+        let entry = entry(r"C:\repo\src\deleted.py:1", "# noqa", "");
+        let scan_paths = vec![PathBuf::from("src")];
+        let registry_dir = PathBuf::from(r"\\?\C:\repo");
         assert!(is_entry_in_scope(
             &entry,
             &HashSet::new(),


### PR DESCRIPTION
Closes #10.

## Summary
- normalize registry absolute-path comparisons through a helper that handles Windows verbatim paths such as `\\?\C:\...`
- reuse the helper in stale-entry scope checks and stale-entry removal normalization
- enable the Windows scoped absolute-path e2e regression that was previously skipped

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build --verbose`
- `uv run ruff check .`
- `PYTHONUTF8=1 uv run pytest e2e_tests/test_registry/test_registry_stale.py -q` -> 11 passed
- `PYTHONUTF8=1 uv run pytest e2e_tests/ -q` -> 292 passed, 3 skipped

Note: on this Windows machine, the workspace path contains non-ASCII characters and Python defaults to the CP949 locale, so the broad Python e2e commands were run with `PYTHONUTF8=1` to avoid local test-runner decoding failures unrelated to this patch.