### PR TITLE
ci(sonar): skip scan for fork PRs

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   sonar:
     name: SonarCloud Analysis
+    # Skip on PRs from forks — secrets.SONAR_TOKEN is unavailable there,
+    # so the scan would always fail with "Project not found".
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Fork PRs can't access `secrets.SONAR_TOKEN` by GitHub's security policy, so the sonar scan always fails with `Project not found`.
- Guard the `sonar` job to run only on `push` events or PRs from the same repository.
- Sonar still runs after merge on `main`, so coverage / quality-gate tracking is preserved.


## Test plan
- [ ] CI checks on this PR (own-branch path): sonar runs as normal.
- [ ] After merge, re-trigger / re-run a fork PR: sonar job should be skipped (no red X).