### PR TITLE
test: cover non-Windows strip_registry_prefix_fallback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1019,4 +1019,23 @@ mod tests {
             &registry_dir,
         ));
     }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn is_entry_in_scope_false_when_absolute_entry_outside_registry() {
+        // Absolute entry whose path is not under the registry directory.
+        // strip_registry_prefix's first attempt fails and the non-Windows
+        // fallback returns None, so the entry stays absolute and matches
+        // neither scanned_files nor any scan_path prefix.
+        let entry = entry("/elsewhere/foo.py:1", "# noqa", "");
+        let scan_paths = vec![PathBuf::from("src")];
+        let registry_dir = PathBuf::from("/repo");
+        assert!(!is_entry_in_scope(
+            &entry,
+            &HashSet::new(),
+            &HashSet::new(),
+            &scan_paths,
+            &registry_dir,
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- added `strip_registry_prefix` with a `#[cfg(not(windows))]` fallback returning `None`. No existing test exercised an absolute entry path outside `registry_dir` on Linux, so the fallback function and the `.or_else` closure were uncovered → SonarCloud line coverage dropped to 98.4%.
- Adds one `#[cfg(not(windows))]` unit test that drives `is_entry_in_scope` with an absolute entry whose path doesn't share the registry prefix. This forces `strip_prefix` to fail, invoking the closure and the fallback's `None` return.

## Local verification

`cargo llvm-cov` on `feat/cov-strip-prefix-fallback`:
- `src/main.rs:108-110` (the non-Windows fallback body): **0 → 2 hits**.
- `strip_registry_prefix` body: 10 hits.

## Test plan
- [ ] CI green on all three OS jobs (Linux/macOS/Windows).
- [ ] SonarCloud "Coverage on new code" reports ≥80% (expected 100% — only new lines are test code).
- [ ] Overall main.rs line coverage returns to baseline.